### PR TITLE
Library capabilities and wrapper for raw script with no boilerplate

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -22,4 +22,3 @@ org.openhab.core.automation.module.script,\
 org.openhab.core.automation.module.script.rulesupport.shared,\
 org.openhab.core.automation.module.script.rulesupport.shared.simple,\
 com.google.gson
-

--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -83,13 +83,11 @@ Bundle your code as OSGI bundle as in this sample: https://github.com/weberjn/or
 
 ${H2} 2nd method : Library annotation
 
-You can also annotate a class with `@org.openhab.automation.javascripting.annotations.Library`. By doing so, the class will be available to all your other java scripts. The library class can still extends the `Script` base class to access its facilities.
+You can also put java files in the `conf/automation/lib/java` directory. By doing so, these libraries will be available to all your java scripts. The library class can still extends the `Script` base class to access its facilities.
 
-You then can access it statically, or you can inject it in your script by using the same annotation on a class member.
+You can then use it normally, or you can even inject it in your script by using the annotation `@org.openhab.automation.javascripting.annotations.Library` on a class member. This injection also allows the library to be instanciated by openHAB and to use all the `Script` facilities, such as access to registries, etc.
 
-Be aware that library instance are not shared between scripts. If you want to share data you should find another way.
-Pay attention to the script load order : a library class must be loaded before being used in another class.
-
+Be aware that a library instance is not shared between scripts. If you want to share data you should find another way.
 
 # Building the Addon
 

--- a/src/main/java/org/openhab/automation/javascripting/annotation/RuleAnnotationParser.java
+++ b/src/main/java/org/openhab/automation/javascripting/annotation/RuleAnnotationParser.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.automation.javascripting.annotations.ChannelEventTrigger;
 import org.openhab.automation.javascripting.annotations.ChannelEventTriggers;
 import org.openhab.automation.javascripting.annotations.CronTrigger;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Jürgen Weber - Initial contribution
  */
-
+@NonNullByDefault
 public class RuleAnnotationParser {
 
     private static Logger logger = LoggerFactory.getLogger(RuleAnnotationParser.class);
@@ -110,113 +111,81 @@ public class RuleAnnotationParser {
             Annotation[] as = m.getDeclaredAnnotations();
             for (Annotation a : as) {
 
-                if (a instanceof CronTrigger) {
-                    CronTrigger trigger = (CronTrigger) a;
-
-                    createCronTrigger(triggerList, trigger);
+                if (a instanceof CronTrigger cronTrigger) {
+                    createCronTrigger(triggerList, cronTrigger);
                 }
 
-                if (a instanceof CronTriggers) {
-                    CronTriggers cronTriggers = (CronTriggers) a;
-
+                if (a instanceof CronTriggers cronTriggers) {
                     for (CronTrigger trigger : cronTriggers.value()) {
                         createCronTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof SystemTrigger) {
-                    SystemTrigger trigger = (SystemTrigger) a;
-
+                if (a instanceof SystemTrigger trigger) {
                     createSystemTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof SystemTriggers) {
-                    SystemTriggers triggers = (SystemTriggers) a;
-
+                if (a instanceof SystemTriggers triggers) {
                     for (SystemTrigger trigger : triggers.value()) {
                         createSystemTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ItemStateChangeTrigger) {
-                    ItemStateChangeTrigger trigger = (ItemStateChangeTrigger) a;
-
+                if (a instanceof ItemStateChangeTrigger trigger) {
                     createItemStateChangeTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ItemStateChangeTriggers) {
-                    ItemStateChangeTriggers triggers = (ItemStateChangeTriggers) a;
-
+                if (a instanceof ItemStateChangeTriggers triggers) {
                     for (ItemStateChangeTrigger trigger : triggers.value()) {
                         createItemStateChangeTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ItemStateUpdateTrigger) {
-                    ItemStateUpdateTrigger trigger = (ItemStateUpdateTrigger) a;
-
+                if (a instanceof ItemStateUpdateTrigger trigger) {
                     createItemStateUpdateTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ItemStateUpdateTriggers) {
-                    ItemStateUpdateTriggers triggers = (ItemStateUpdateTriggers) a;
-
+                if (a instanceof ItemStateUpdateTriggers triggers) {
                     for (ItemStateUpdateTrigger trigger : triggers.value()) {
                         createItemStateUpdateTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ThingStateUpdateTrigger) {
-                    ThingStateUpdateTrigger trigger = (ThingStateUpdateTrigger) a;
-
+                if (a instanceof ThingStateUpdateTrigger trigger) {
                     createThingStateUpdateTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ThingStateUpdateTriggers) {
-                    ThingStateUpdateTriggers triggers = (ThingStateUpdateTriggers) a;
-
+                if (a instanceof ThingStateUpdateTriggers triggers) {
                     for (ThingStateUpdateTrigger trigger : triggers.value()) {
                         createThingStateUpdateTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ThingStateChangeTrigger) {
-                    ThingStateChangeTrigger trigger = (ThingStateChangeTrigger) a;
-
+                if (a instanceof ThingStateChangeTrigger trigger) {
                     createThingStateChangeTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ThingStateChangeTriggers) {
-                    ThingStateChangeTriggers triggers = (ThingStateChangeTriggers) a;
-
+                if (a instanceof ThingStateChangeTriggers triggers) {
                     for (ThingStateChangeTrigger trigger : triggers.value()) {
                         createThingStateChangeTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ItemCommandTrigger) {
-                    ItemCommandTrigger trigger = (ItemCommandTrigger) a;
-
+                if (a instanceof ItemCommandTrigger trigger) {
                     createItemCommandTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ItemCommandTriggers) {
-                    ItemCommandTriggers triggers = (ItemCommandTriggers) a;
-
+                if (a instanceof ItemCommandTriggers triggers) {
                     for (ItemCommandTrigger trigger : triggers.value()) {
                         createItemCommandTrigger(triggerList, trigger);
                     }
                 }
 
-                if (a instanceof ChannelEventTrigger) {
-                    ChannelEventTrigger trigger = (ChannelEventTrigger) a;
-
+                if (a instanceof ChannelEventTrigger trigger) {
                     createChannelEventTrigger(triggerList, trigger);
                 }
 
-                if (a instanceof ChannelEventTriggers) {
-                    ChannelEventTriggers triggers = (ChannelEventTriggers) a;
-
+                if (a instanceof ChannelEventTriggers triggers) {
                     for (ChannelEventTrigger trigger : triggers.value()) {
                         createChannelEventTrigger(triggerList, trigger);
                     }

--- a/src/main/java/org/openhab/automation/javascripting/annotation/SimpleMethodRule.java
+++ b/src/main/java/org/openhab/automation/javascripting/annotation/SimpleMethodRule.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.automation.javascripting.scriptsupport.Script;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.module.script.rulesupport.shared.simple.SimpleRule;
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Gwendal Roulleau - Initial contribution
  */
-
+@NonNullByDefault
 public class SimpleMethodRule extends SimpleRule {
 
     private static Logger logger = LoggerFactory.getLogger(SimpleMethodRule.class);
@@ -52,7 +52,7 @@ public class SimpleMethodRule extends SimpleRule {
     }
 
     @Override
-    public @NonNull Object execute(@NonNull Action module, @NonNull Map<@NonNull String, ?> inputs) {
+    public Object execute(Action module, Map<String, ?> inputs) {
         Object returnObject = null;
         try {
             returnObject = method.invoke(script, inputs);

--- a/src/main/java/org/openhab/automation/javascripting/annotations/Library.java
+++ b/src/main/java/org/openhab/automation/javascripting/annotations/Library.java
@@ -10,24 +10,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
+package org.openhab.automation.javascripting.annotations;
 
-package org.openhab.automation.javascripting.annotation;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * @author Gwendal Roulleau - Initial contribution
  */
-@NonNullByDefault
-public class RuleParserException extends Exception {
+@Retention(RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD })
+public @interface Library {
 
-    private static final long serialVersionUID = 5744217657057910494L;
-
-    RuleParserException(String message, Throwable e) {
-        super(message, e);
-    }
-
-    RuleParserException(String message) {
-        super(message);
-    }
 }

--- a/src/main/java/org/openhab/automation/javascripting/internal/BulkBindingStrategy.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/BulkBindingStrategy.java
@@ -53,7 +53,8 @@ public class BulkBindingStrategy implements BindingStrategy {
                     field.set(compiledInstance, libraryInstance);
                 } catch (InstantiationException | InvocationTargetException | NoSuchMethodException | SecurityException
                         | IllegalArgumentException | IllegalAccessException e) {
-                    logger.error("Cannot inject library into {}", field.getName(), e);
+                    logger.error("Cannot inject library instance into {}. Do you have an empty constructor ?",
+                            field.getName(), e);
                 }
             }
         }

--- a/src/main/java/org/openhab/automation/javascripting/internal/EntryExecutionStrategyFactory.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/EntryExecutionStrategyFactory.java
@@ -17,7 +17,6 @@ import javax.script.ScriptException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.automation.javascripting.annotations.Library;
 import org.openhab.automation.javascripting.scriptsupport.Script;
 
 import ch.obermuhlner.scriptengine.java.execution.ExecutionStrategy;
@@ -29,29 +28,31 @@ import ch.obermuhlner.scriptengine.java.execution.ExecutionStrategyFactory;
 @NonNullByDefault
 public class EntryExecutionStrategyFactory implements ExecutionStrategyFactory {
 
+    private final static ExecutionStrategy scriptExecutionStrategy = new ScriptExecutionStrategy();
+
     @Override
     public ExecutionStrategy create(@Nullable Class<?> clazz) throws ScriptException {
 
-        return new ExecutionStrategy() {
+        return scriptExecutionStrategy;
+    }
 
-            @Override
-            public @Nullable Object execute(@Nullable Object instance) throws ScriptException {
-                try {
-                    if (instance instanceof Script) {
-                        Script script = (Script) instance;
-                        return script.eval();
-                    } else if (instance != null && instance.getClass().isAnnotationPresent(Library.class)) {
-                        return null;
-                    } else {
-                        String simpleName = instance == null ? "unknown" : instance.getClass().getSimpleName();
-                        throw new ScriptException(String.format("cannot execute: %s not instance of %s", simpleName,
-                                Script.class.getName()));
-                    }
+    private static class ScriptExecutionStrategy implements ExecutionStrategy {
 
-                } catch (Exception e) {
-                    throw new ScriptException(e);
+        @Override
+        public @Nullable Object execute(@Nullable Object instance) throws ScriptException {
+            try {
+                if (instance instanceof Script) {
+                    Script script = (Script) instance;
+                    return script.eval();
+                } else {
+                    String simpleName = instance == null ? "unknown" : instance.getClass().getSimpleName();
+                    throw new ScriptException(
+                            String.format("cannot execute: %s not instance of %s", simpleName, Script.class.getName()));
                 }
+
+            } catch (Exception e) {
+                throw new ScriptException(e);
             }
-        };
+        }
     }
 }

--- a/src/main/java/org/openhab/automation/javascripting/internal/EntryExecutionStrategyFactory.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/EntryExecutionStrategyFactory.java
@@ -15,9 +15,10 @@ package org.openhab.automation.javascripting.internal;
 
 import javax.script.ScriptException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.automation.javascripting.annotations.Library;
 import org.openhab.automation.javascripting.scriptsupport.Script;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ch.obermuhlner.scriptengine.java.execution.ExecutionStrategy;
 import ch.obermuhlner.scriptengine.java.execution.ExecutionStrategyFactory;
@@ -25,31 +26,27 @@ import ch.obermuhlner.scriptengine.java.execution.ExecutionStrategyFactory;
 /**
  * @author Jürgen Weber - Initial contribution
  */
-
+@NonNullByDefault
 public class EntryExecutionStrategyFactory implements ExecutionStrategyFactory {
 
-    private static Logger logger = LoggerFactory.getLogger(EntryExecutionStrategyFactory.class);
-
     @Override
-    public ExecutionStrategy create(Class<?> clazz) throws ScriptException {
+    public ExecutionStrategy create(@Nullable Class<?> clazz) throws ScriptException {
 
         return new ExecutionStrategy() {
 
             @Override
-            public Object execute(Object instance) throws ScriptException {
-
-                Object retval = null;
-
+            public @Nullable Object execute(@Nullable Object instance) throws ScriptException {
                 try {
                     if (instance instanceof Script) {
                         Script script = (Script) instance;
-
-                        retval = script.eval();
+                        return script.eval();
+                    } else if (instance != null && instance.getClass().isAnnotationPresent(Library.class)) {
+                        return null;
                     } else {
-                        throw new ScriptException(String.format("cannot execute: %s not instance of %s",
-                                instance.getClass().getSimpleName(), Script.class.getName()));
+                        String simpleName = instance == null ? "unknown" : instance.getClass().getSimpleName();
+                        throw new ScriptException(String.format("cannot execute: %s not instance of %s", simpleName,
+                                Script.class.getName()));
                     }
-                    return retval;
 
                 } catch (Exception e) {
                     throw new ScriptException(e);

--- a/src/main/java/org/openhab/automation/javascripting/internal/IncludeLibraryCompilationStrategy.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/IncludeLibraryCompilationStrategy.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.javascripting.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import javax.tools.JavaFileObject;
+
+import org.openhab.automation.javascripting.annotations.Library;
+
+import ch.obermuhlner.scriptengine.java.MemoryFileManager;
+import ch.obermuhlner.scriptengine.java.compilation.CompilationStrategy;
+
+/**
+ * @author Gwendal Roulleau - Initial contribution
+ */
+public class IncludeLibraryCompilationStrategy implements CompilationStrategy {
+    Map<String, JavaFileObject> previousFileObject = new HashMap<>();
+
+    JavaFileObject currentJavaFileObject;
+
+    @Override
+    public List<JavaFileObject> getJavaFileObjectsToCompile(String simpleClassName, String currentSource) {
+        currentJavaFileObject = MemoryFileManager.createSourceFileObject(null, simpleClassName, currentSource);
+        Stream<JavaFileObject> previousFileObjects = previousFileObject.entrySet().stream()
+                .filter(entry -> !entry.getKey().equals(simpleClassName)) // do no keep the old file
+                .map(Entry::getValue);
+        return Stream.concat(previousFileObjects, Stream.of(currentJavaFileObject)).toList();
+    }
+
+    @Override
+    public void compilationResult(Class<?> clazz) {
+        JavaFileObject currentJavaFileObjectLocal = currentJavaFileObject;
+        if (clazz.isAnnotationPresent(Library.class) && currentJavaFileObjectLocal != null) {
+            previousFileObject.put(clazz.getSimpleName(), currentJavaFileObjectLocal);
+        }
+    }
+}

--- a/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptEngineFactory.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptEngineFactory.java
@@ -12,24 +12,33 @@
  */
 package org.openhab.automation.javascripting.internal;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Stream;
 
 import javax.script.ScriptEngine;
+import javax.script.ScriptException;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.OpenHAB;
 import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
+import org.openhab.core.service.WatchService;
+import org.openhab.core.service.WatchService.Kind;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.obermuhlner.scriptengine.java.JavaScriptEngine;
-import ch.obermuhlner.scriptengine.java.compilation.CompilationStrategy;
 import ch.obermuhlner.scriptengine.java.packagelisting.PackageResourceListingStrategy;
 
 /**
@@ -39,8 +48,11 @@ import ch.obermuhlner.scriptengine.java.packagelisting.PackageResourceListingStr
  *
  * @author Jürgen Weber - Initial contribution
  */
-@Component(service = ScriptEngineFactory.class)
-public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
+@Component(service = { ScriptEngineFactory.class, JavaScriptEngineFactory.class })
+public class JavaScriptEngineFactory extends AbstractScriptEngineFactory implements WatchService.WatchEventListener {
+
+    public static final Path LIB_DIR = Path.of(OpenHAB.getConfigFolder(), "automation", "lib",
+            JavaScriptingConstants.JAVA_FILE_TYPE);
 
     private static final Logger logger = LoggerFactory.getLogger(JavaScriptEngineFactory.class);
 
@@ -48,15 +60,18 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
 
     private ch.obermuhlner.scriptengine.java.JavaScriptEngineFactory javaScriptEngineFactory;
 
-    private CompilationStrategy compilationStrategy = new IncludeLibraryCompilationStrategy();
+    private IncludeLibraryCompilationStrategy withLibrariesCompilationStrategy = new IncludeLibraryCompilationStrategy();
 
     private PackageResourceListingStrategy osgiPackageResourceListingStrategy;
 
+    private final WatchService watchService;
+
     @Activate
-    protected void activate(BundleContext context, Map<String, ?> config) {
+    public JavaScriptEngineFactory(BundleContext bundleContext,
+            @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService) {
+        this.watchService = watchService;
 
         osgiPackageResourceListingStrategy = new PackageResourceListingStrategy() {
-
             @Override
             public Collection<String> listResources(String packageName) {
                 return listClassResources(packageName);
@@ -65,19 +80,34 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
 
         javaScriptEngineFactory = new ch.obermuhlner.scriptengine.java.JavaScriptEngineFactory();
 
-        bundleWiring = context.getBundle().adapt(BundleWiring.class);
+        bundleWiring = bundleContext.getBundle().adapt(BundleWiring.class);
+
+        try {
+            Files.createDirectories(LIB_DIR);
+        } catch (IOException e) {
+            logger.warn("Failed to create directory '{}': {}", LIB_DIR, e.getMessage());
+            throw new IllegalStateException("Failed to initialize lib folder.");
+        }
+
+        scanLibDirectory();
+        watchService.registerListener(this, LIB_DIR);
 
         logger.info("Bundle activated");
     }
 
+    @Deactivate
+    public void deactivate() {
+        watchService.unregisterListener(this);
+    }
+
     @Override
     public List<String> getScriptTypes() {
-        String[] types = { "java" };
+        String[] types = { JavaScriptingConstants.JAVA_FILE_TYPE };
         return Arrays.asList(types);
     }
 
     @Override
-    public ScriptEngine createScriptEngine(String scriptType) {
+    public @Nullable ScriptEngine createScriptEngine(String scriptType) {
         if (getScriptTypes().contains(scriptType)) {
 
             JavaScriptEngine engine = (JavaScriptEngine) javaScriptEngineFactory.getScriptEngine();
@@ -88,7 +118,7 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
 
             engine.setBindingStrategy(new BulkBindingStrategy());
 
-            engine.setCompilationStrategy(compilationStrategy);
+            engine.setCompilationStrategy(withLibrariesCompilationStrategy);
 
             engine.setScriptInterceptorStrategy(new ScriptWrappingStategy());
 
@@ -109,5 +139,26 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
         Collection<String> resources = bundleWiring.listResources(path, "*.class", 0);
 
         return resources;
+    }
+
+    private void scanLibDirectory() {
+        try {
+            Stream<Path> javaFileWalk = Files.walk(LIB_DIR).filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith("." + JavaScriptingConstants.JAVA_FILE_TYPE));
+            withLibrariesCompilationStrategy.setLibraries(javaFileWalk.toList());
+        } catch (IOException | ScriptException e) {
+            logger.error("Cannot use libraries", e);
+        }
+    }
+
+    @Override
+    public void processWatchEvent(WatchService.Kind kind, Path path) {
+        Path fullPath = LIB_DIR.resolve(path);
+        if (fullPath.getFileName().toString().endsWith("." + JavaScriptingConstants.JAVA_FILE_TYPE)
+                && (kind == Kind.CREATE || kind == Kind.MODIFY || kind == Kind.DELETE)) {
+            scanLibDirectory();
+        } else {
+            logger.trace("Received '{}' for path '{}' - ignoring (wrong extension)", kind, fullPath);
+        }
     }
 }

--- a/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptEngineFactory.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptEngineFactory.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import ch.obermuhlner.scriptengine.java.JavaScriptEngine;
+import ch.obermuhlner.scriptengine.java.compilation.CompilationStrategy;
 import ch.obermuhlner.scriptengine.java.packagelisting.PackageResourceListingStrategy;
 
 /**
@@ -46,6 +47,8 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
     BundleWiring bundleWiring;
 
     private ch.obermuhlner.scriptengine.java.JavaScriptEngineFactory javaScriptEngineFactory;
+
+    private CompilationStrategy compilationStrategy = new IncludeLibraryCompilationStrategy();
 
     private PackageResourceListingStrategy osgiPackageResourceListingStrategy;
 
@@ -84,6 +87,10 @@ public class JavaScriptEngineFactory extends AbstractScriptEngineFactory {
             engine.setPackageResourceListingStrategy(osgiPackageResourceListingStrategy);
 
             engine.setBindingStrategy(new BulkBindingStrategy());
+
+            engine.setCompilationStrategy(compilationStrategy);
+
+            engine.setScriptInterceptorStrategy(new ScriptWrappingStategy());
 
             engine.setCompilationOptions(Arrays.asList("-g"));
 

--- a/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptingConstants.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/JavaScriptingConstants.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.javascripting.internal;
+
+/**
+ *
+ * @author Gwendal Roulleau - initial contribution
+ *
+ */
+public class JavaScriptingConstants {
+
+    public static final String JAVA_FILE_TYPE = "java";
+}

--- a/src/main/java/org/openhab/automation/javascripting/internal/ScriptWrappingStategy.java
+++ b/src/main/java/org/openhab/automation/javascripting/internal/ScriptWrappingStategy.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.automation.javascripting.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.obermuhlner.scriptengine.java.compilation.ScriptInterceptorStrategy;
+
+/**
+ * Wrapps a script in boilerplate code if not present.
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+public class ScriptWrappingStategy implements ScriptInterceptorStrategy {
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("public\\s+class\\s+.*");
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile("package\\s+[A-Za-z][A-Za-z0-9_$.]*;\\s*");
+    private static final Pattern IMPORT_PATTERN = Pattern.compile("import\\s+[A-Za-z][A-Za-z0-9_$.]*;\\s*");
+
+    private static String BOILERPLATE_CODE_BEFORE = """
+            import org.openhab.automation.javascripting.scriptsupport.Script;
+            public class WrappedJavaScript extends Script {
+                protected Object onLoad() {
+            """;
+
+    private static String BOILERPLATE_CODE_AFTER = """
+                }
+            }
+            """;
+
+    @Override
+    public @Nullable String intercept(@Nullable String script) {
+        if (script == null) {
+            return "";
+        }
+        List<@NonNull String> lines = script.lines().toList();
+
+        String packageDeclarationLine = "";
+        List<String> importLines = new ArrayList<>(lines.size());
+        List<String> scriptLines = new ArrayList<>(lines.size());
+        boolean returnIsPresent = false;
+
+        for (String line : lines) {
+            line = line.trim();
+            if (NAME_PATTERN.matcher(line).matches()) { // a class declaration is found. No need to wrap
+                return script;
+            }
+            if (PACKAGE_PATTERN.matcher(line).matches()) {
+                packageDeclarationLine = line;
+            } else if (IMPORT_PATTERN.matcher(line).matches()) {
+                importLines.add(line);
+            } else {
+                if (line.startsWith("return")) {
+                    returnIsPresent = true;
+                }
+                scriptLines.add(line);
+            }
+        }
+
+        StringBuilder modifiedScript = new StringBuilder();
+        modifiedScript.append(packageDeclarationLine + "\n");
+        modifiedScript.append(String.join("\n", importLines));
+        modifiedScript.append(BOILERPLATE_CODE_BEFORE);
+        modifiedScript.append(String.join("\n", scriptLines));
+        if (!returnIsPresent) {
+            modifiedScript.append("return null;");
+        }
+        modifiedScript.append(BOILERPLATE_CODE_AFTER);
+
+        return modifiedScript.toString();
+    }
+}

--- a/src/main/java/org/openhab/automation/javascripting/scriptsupport/Script.java
+++ b/src/main/java/org/openhab/automation/javascripting/scriptsupport/Script.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base Class for all Java Scripts
- * 
+ *
  * @author Jürgen Weber - Initial contribution
  */
 
@@ -216,8 +216,6 @@ public abstract class Script {
         }
 
         public void invoke(ThingActions thingActions, String method, Object... params) {
-            Object o;
-
             Class<?>[] paramClasses = new Class<?>[params.length];
 
             for (int i = 0; i < params.length; i++) {
@@ -226,7 +224,7 @@ public abstract class Script {
             try {
 
                 Method m = thingActions.getClass().getMethod(method, paramClasses);
-                o = m.invoke(thingActions, params);
+                m.invoke(thingActions, params);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -240,6 +238,23 @@ public abstract class Script {
     public Object eval() throws Exception {
 
         logger.trace("eval()");
+
+        try {
+
+            Object result;
+
+            result = onLoad();
+            parseAnnotations();
+
+            return result;
+
+        } catch (Exception e) {
+            logger.error("Script eval", e);
+            throw e;
+        }
+    }
+
+    public void makeShortcuts() {
 
         Object se = bindings.get("se");
 
@@ -268,20 +283,6 @@ public abstract class Script {
         // input is set for transformations
 
         input = bindings.get("input");
-
-        try {
-
-            Object result;
-
-            result = onLoad();
-            parseAnnotations();
-
-            return result;
-
-        } catch (Exception e) {
-            logger.error("Script eval", e);
-            throw e;
-        }
     }
 
     /*
@@ -299,7 +300,9 @@ public abstract class Script {
     }
 
     // to be implemented by the concrete script class
-    protected abstract Object onLoad();
+    protected Object onLoad() {
+        return null;
+    }
 
     private void parseAnnotations() throws Exception {
         new RuleAnnotationParser(this).parse();

--- a/src/script/java/MyLib.java
+++ b/src/script/java/MyLib.java
@@ -1,0 +1,16 @@
+package mypackage;
+
+import org.openhab.automation.javascripting.scriptsupport.Script;
+import org.openhab.automation.javascripting.annotations.Library;
+
+@Library
+public class MyLib extends Script {
+
+    public static void sayStaticHello() {
+        logger.info("Static Hello word");
+    }
+    
+    public void sayHello() {
+        logger.info("Hello word"); 
+    }    
+}

--- a/src/script/java/RawScript.jav
+++ b/src/script/java/RawScript.jav
@@ -1,0 +1,4 @@
+import java.util.UUID;
+
+UUID uuid = UUID.randomUUID();
+return uuid.toString();

--- a/src/script/java/SendMail.java
+++ b/src/script/java/SendMail.java
@@ -11,9 +11,8 @@ public class SendMail extends Script {
     @Override
     protected Object onLoad() {
 
-        ThingActions thingActions = actions.get("mail", "mail:smtp:local");
-        
-        actions.invoke(thingActions, "sendMail", "weberjn", "java sendmail", "mailcontent Java script onload()");
+        ThingActions thingActions = actions.get("mail", "mail:smtp:mailSender");
+        actions.invoke(thingActions, "mail_at_receiver", "a subject", "mailcontent Java script onload()");
 
         logger.info("mail sent");
         

--- a/src/script/java/UseLib.java
+++ b/src/script/java/UseLib.java
@@ -1,0 +1,16 @@
+import org.openhab.automation.javascripting.scriptsupport.Script;
+
+import java.util.Map;
+import mypackage.MyLib;
+
+public class UseLib extends Script {
+
+    @org.openhab.automation.javascripting.annotations.Library
+    MyLib mylib;
+
+    public Object onLoad() {
+        mylib.sayHello();
+        MyLib.sayStaticHello();
+        return null;
+    }
+}


### PR DESCRIPTION
Hello @weberjn 

Two functionnalities in this PR, sorry I should have splitted this but I did the two dev at the same time.

- First : the use of Libraries with the new "Compilation" strategy I pushed to the java-jsr implementation upstream. The README will tell you more.
- Second : the possibility to make a "raw" script with no boiler plate code with the a wrapping strategy using the InterceptorStrategy I also pushed upstream. Also in the README


Technical note explaining some modifications : 

- I moved the phase when we set all the "shortcut" properties into the "associateBindings" step instead of inside the "eval" method.
Because first it seems a better place ? (it's a kind of binding), and second I needed it to separate it for libraries, which have no "eval" phase.

- some little modifications (essentially fixing warnings with nullable, or unused variable, or syntaxic sugar)

- why on BulkBindingStrategy do you use reflection to call method from the Script class ? I assumed it was some older code from something not usefull anymore, because it seems to works without reflection ? I can of course revert this part if there is some reason I'm missing.

- I have the same question on the Script class : by casting the "events" property to the right class we should be able to avoid completely the ScriptBusEventProxy ? (I didn't make the modification for this one)

- I made a default onLoad method, that does nothing. Don't know if you will agree, but I have two use cases where this method ads unecessary constraints : 
-- not usefull if rules are defined with annotations
-- not usefull for libraries
Is it OK ?